### PR TITLE
Fix redux logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 								<ul>
 								<li><i class="devicon-javascript-plain colored"></i></li>
 								<li><i class="devicon-react-original-wordmark colored"></i></li>
-								<li><img height="100" src="https://codedistrict.io/wp-content/uploads/2017/12/reduxLogo.png"></li>
+								<li><img height="100" src="https://upload.wikimedia.org/wikipedia/commons/4/49/Redux.png"></li>
 								<li><img height="100" src="https://montykamath.files.wordpress.com/2018/02/graphql.png"></li>
 								<li><i class="devicon-html5-plain-wordmark colored"></i></li>
 								<li><i class="devicon-css3-plain-wordmark colored"></i></li>


### PR DESCRIPTION
Looks really good, but redux logo is not loading. Users get a forbidden message when trying to access the image link.
Using the wikimedia version of the logo for long term use.